### PR TITLE
feat: add Dockerfile and .dockerignore for Coolify deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.env
+.devcontainer
+.context
+node_modules
+tasks

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM denoland/deno:2.6.8
+
+WORKDIR /app
+
+COPY deno.json deno.lock ./
+RUN deno install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["deno", "task", "http"]


### PR DESCRIPTION
Adds production-ready Docker configuration for deploying to Coolify.

- Uses `denoland/deno:2.6.8` matching the lockfile v5 requirement
- Dependencies cached in separate layer for fast rebuilds
- Exposes port 3000 (configurable via PORT env var)
- Excludes dev/git artifacts from image

Requires setting `PAYMENT_ADDRESS`, `PRIVATE_KEY`, and other env vars in Coolify.

🤖 Generated with Claude Code